### PR TITLE
Add support for Flow

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -3,10 +3,13 @@
     "eslint-config-kyt"
   ],
 
+  "parser": "babel-eslint",
+
   "env": {
   },
 
   "plugins": [
+    "flowtype"
   ],
 
   "rules": {

--- a/.flowconfig
+++ b/.flowconfig
@@ -1,0 +1,2 @@
+[options]
+module.name_mapper.extension='scss' -> 'empty/object'

--- a/package.json
+++ b/package.json
@@ -19,7 +19,11 @@
     "@kadira/storybook": "^2.21.0",
     "@types/enzyme": "^2.7.6",
     "@types/jest": "^19.2.2",
+    "babel-eslint": "^7.2.1",
+    "empty": "^0.10.1",
     "enzyme": "^2.4.1",
+    "eslint-plugin-flowtype": "^2.30.4",
+    "flow-bin": "^0.42.0",
     "react-addons-test-utils": "^15.3.0"
   },
   "repository": {
@@ -29,6 +33,7 @@
   "scripts": {
     "dev": "kyt dev",
     "build": "kyt build",
+    "flow": "flow; test $? -eq 0 -o $? -eq 2",
     "start": "node build/server/main.js",
     "proto": "kyt proto",
     "test": "kyt test",

--- a/src/components/01-atoms/RoomLabel/index.js
+++ b/src/components/01-atoms/RoomLabel/index.js
@@ -1,8 +1,9 @@
+// @flow
 
 import React, { PropTypes } from 'react';
 import styles from './styles.scss';
 
-const RoomLabel = ({ name = '' }) => (
+const RoomLabel = ({ name = '' }: { name: string }) => (
   <div className={styles.roomLabel}>
     <span className={styles.foo}>{ name }</span>
   </div>


### PR DESCRIPTION
- Demo a very simple example of Flow usage in RoomLabel/index.js
- Modify ESLint config to play nice with Flow. See: https://github.com/gajus/eslint-plugin-flowtype and http://stackoverflow.com/questions/36258234/eslint-with-arbnb-config-and-facebook-flow-together
- Trick Flow into playing nice with scss module imports. See: https://github.com/facebook/flow/issues/338