### PR TITLE
Specify a start script

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Bookit is a web app aimed at providing a neat way to book meeting rooms in the D
 ## Quick start
 ```
 npm install
-npm run dev
+npm start
 ```
 
 ## Useful scripts

--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
   "scripts": {
     "dev": "kyt dev",
     "build": "kyt build",
-    "start": "node build/server/main.js",
+    "start": "npm run dev",
     "proto": "kyt proto",
     "test": "npm run lint && kyt test",
     "test-watch": "kyt test -- --watch",


### PR DESCRIPTION
In following (what seems to be) a node convention, I'm aiming to make it a little bit easier to remember how to start this thing up in dev mode. `npm run dev` is very specific to our app. By aliasing `npm start` we can give an easy, recognizable entry point.